### PR TITLE
Slackware - DHCP Client

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -574,7 +574,11 @@
     # Description : Checking for DHCP client
     Register --test-no NETW-3030 --weight L --network NO --category security --description "Checking DHCP client status"
     if [ ${SKIPTEST} -eq 0 ]; then
-        IsRunning dhclient
+        if [ ${OS} = "Slackware" ]; then
+            IsRunning dchpcd
+        else
+            IsRunning dhclient
+        fi
         if [ ${RUNNING} -eq 1 ]; then
             Display --indent 2 --text "- Checking status DHCP client" --result "${STATUS_RUNNING}" --color WHITE
             DHCP_CLIENT_RUNNING=1


### PR DESCRIPTION
Slackware utilizes ‘dhcpcd’ instead of ‘dhclient’ as a DHCP client. Adjustments made to accommodate.